### PR TITLE
Use Erubis instead of ERB

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 > Embedded Ruby (`.erb`) Webpack loader for Ruby on Rails projects.
 
-Compiles Embedded Ruby template files in a Rails project. Files are piped through the `ERB` gem via a call to `rails runner`.
+Compiles Embedded Ruby template files in a Rails project. Files are piped through the `Erubis` gem via a call to `rails runner`.
 
 ## Table of Contents
 - [Install](#install)

--- a/erb_transformer.rb
+++ b/erb_transformer.rb
@@ -1,4 +1,4 @@
-require 'erb'
+require 'erubis'
 
 delimiter = ARGV[0]
-puts "#{delimiter}#{ERB.new(STDIN.read).result}#{delimiter}"
+puts "#{delimiter}#{Erubis::Eruby.new(STDIN.read).result}#{delimiter}"


### PR DESCRIPTION
Erubis is a faster implementation of ERB and Rails ships with erubis since Rails 3.0 so it can be used in any rails project.