### PR TITLE
Change arrow function syntax in a callback

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ function parseBool (string) {
 
 // Get each space separated path, ignoring any empty strings.
 function parseDependencies (root, string) {
-  return string.split(/\s+/).reduce((accumulator, dependency) => {
+  return string.split(/\s+/).reduce(function(accumulator, dependency) {
     if (dependency.length > 0) {
       var absolutePath = path.resolve(root, defaultFileExtension(dependency))
       accumulator.push(absolutePath)


### PR DESCRIPTION
Older function syntax does not cause errors in versions of node that do not
support ES2015 arrow function syntax.
According to http://node.green/#arrow-functions arrow functions are not out-of-the-box supported in 0.12 and 0.10 versions of node.

I came up with this issue on a debian machine that unfortunately works with node 0.10.29. The error was: 
```
return string.split(/\s+/).reduce((accumulator, dependency) => {
                                                               ^
SyntaxError: Unexpected token >

```
Switching to the `function` syntax supports these versions of node  too.