### PR TITLE
Remove node-uuid

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,12 +1,16 @@
 var exec = require('child_process').exec
 var path = require('path')
-var uuid = require('node-uuid')
 var loaderUtils = require('loader-utils')
 var defaults = require('lodash.defaults')
 
 function pushAll (dest, src) {
   Array.prototype.push.apply(dest, src)
 }
+
+/* Create a delimeter that is unlikely to appear in parsed code. I've split this
+ * string deliberately in case this file accidentally ends up being transpiled
+ */
+var ioDelimiter = '_' + '_RAILS_ERB_LOADER_DELIMETER__'
 
 /* Match any block comments that start with the string `rails-erb-loader-*`. */
 var configCommentRegex = /\/\*\s*rails-erb-loader-([a-z-]*)\s*([\s\S]*?)\s*\*\//g
@@ -74,7 +78,6 @@ function parseComments (source, config) {
  * output transformed source.
  */
 function transformSource (source, map, callback) {
-  var ioDelimiter = uuid.v4()
   var child = exec(
     './bin/rails runner ' + path.join(__dirname, 'erb_transformer.rb') + ' ' + ioDelimiter,
     function (error, stdout) {

--- a/package.json
+++ b/package.json
@@ -26,8 +26,7 @@
   "homepage": "https://github.com/usabilityhub/rails-erb-loader#readme",
   "dependencies": {
     "loader-utils": "^0.2.16",
-    "lodash.defaults": "^4.2.0",
-    "node-uuid": "^1.4.7"
+    "lodash.defaults": "^4.2.0"
   },
   "devDependencies": {
     "eslint": "^3.9.1",


### PR DESCRIPTION
`node-uuid` package has been deprecated in favor of `uuid`. Instead just remove it entirely and rely on a string constant.

Closes #11