### PR TITLE
Lint for unsupported features

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,9 +1,10 @@
 {
   "extends": "standard",
+  "plugins": ["node"],
   "parserOptions": {
-    "ecmaVersion": 5
+    "ecmaVersion": 2017
   },
-  "env": {
-    "es6": false
+  "rules": {
+    "node/no-unsupported-features": ["error", { "ignores": ["blockScopedFunctions"] }]
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "3.0.0",
   "description": "Embedded Ruby (`.erb`) Webpack loader for Ruby on Rails projects.",
   "main": "index.js",
+  "engines": {
+    "node": ">=0.10.0"
+  },
   "scripts": {
     "lint": "eslint index.js",
     "test": "echo \"Error: no test specified\" && exit 1"
@@ -29,8 +32,9 @@
     "lodash.defaults": "^4.2.0"
   },
   "devDependencies": {
-    "eslint": "^3.9.1",
+    "eslint": "^3.11.1",
     "eslint-config-standard": "^6.2.1",
+    "eslint-plugin-node": "^3.0.4",
     "eslint-plugin-promise": "^3.3.0",
     "eslint-plugin-standard": "^2.0.1"
   }


### PR DESCRIPTION
Lint for JS features not supported by Node 0.10.0.

Ignore the `"blockScopedFunctions"` rule beacuse it seems to be buggy. See mysticatea/eslint-plugin-node#59.