### PR TITLE
Suppress EPIPE error on 'command not found'

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,18 @@ function transformSource (runner, engine, source, map, callback) {
       callback(error, transformedSource, map)
     }
   )
+  child.stdin.on('error', function (error) {
+    if (error.code === 'EPIPE') {
+      // When the `runner` command is not found, stdin will not be open.
+      // Attemping to write then causes an EPIPE error. Ignore this because the
+      // `exec` callback gives a more meaningful error that we show to the user.
+    } else {
+      console.error(
+        'rails-erb-loader encountered an unexpected error while writing to stdin: "' +
+        error.message + '". Please report this to the maintainers.'
+      )
+    }
+  })
   child.stdin.write(source)
   child.stdin.end()
 }


### PR DESCRIPTION
When an invalid `runner` option is supplied, the loader would crash the entire webpack process with an EPIPE error. This was caused by attempting to pass the file contents to stdin without handling the error.