### PR TITLE
Update loader-utils to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 
 Compiles Embedded Ruby template files in any Ruby project. Files are built using either the `Erubis` or `ERB` gem.
 
+**NOTE:** For compatibility with webpack 1, please use [version 3.2.0](https://github.com/usabilityhub/rails-erb-loader/tree/3.2.0).
+
 ## Table of Contents
 - [Install](#install)
 - [Usage](#usage)
@@ -33,9 +35,16 @@ Add `rails-erb-loader` to your preloaders.
 // webpack.config.js
 
 module.exports = {
-  preLoaders: [
-    { test: /\.erb$/, loader: 'rails-erb-loader' },
-  ]
+    module: {
+      rules: [
+        {
+          test: /\.erb$/,
+          enforce: 'pre',
+          loader: 'rails-erb-loader'
+        },
+      ]
+    }
+  }
 };
 ```
 
@@ -56,24 +65,26 @@ Can be configured with [query parameters](https://webpack.github.io/docs/using-l
 These options may also be specified directly in your `webpack` config. For example, if your `webpack` process is running in a subdirectory of your Rails project:
 
 ```js
-module.exports = {
-  railsErbLoader: {
+{
+  test: /\.erb$/,
+  loader: 'rails-erb-loader',
+  options: {
     runner: '../bin/rails runner',
     dependenciesRoot: '../app',
-  },
-  // ...
+  }
 }
 ```
 
 Also supports building without Rails:
 
 ```js
-module.exports = {
-  railsErbLoader: {
+{
+  test: /\.erb$/,
+  loader: 'rails-erb-loader',
+  options: {
     runner: 'ruby',
     engine: 'erb'
-  },
-  // ...
+  }
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var exec = require('child_process').exec
 var path = require('path')
-var loaderUtils = require('loader-utils')
+var getOptions = require('loader-utils').getOptions
 var defaults = require('lodash.defaults')
 var util = require('util')
 
@@ -107,7 +107,8 @@ module.exports = function railsErbLoader (source, map) {
   loader.cacheable()
 
   // Get options passed in the loader query, or use defaults.
-  var config = defaults(loaderUtils.getLoaderConfig(loader, 'railsErbLoader'), {
+  // Modifying the return value of `getOptions` is not permitted.
+  var config = defaults({}, getOptions(loader), {
     dependencies: [],
     dependenciesRoot: 'app',
     parseComments: true,

--- a/package.json
+++ b/package.json
@@ -34,8 +34,11 @@
   },
   "homepage": "https://github.com/usabilityhub/rails-erb-loader#readme",
   "dependencies": {
-    "loader-utils": "^0.2.16",
+    "loader-utils": "^1.1.0",
     "lodash.defaults": "^4.2.0"
+  },
+  "peerDependencies": {
+    "webpack": "2"
   },
   "devDependencies": {
     "eslint": "^3.11.1",


### PR DESCRIPTION
Use `getOptions` instead of the deprecated `getLoaderConfig`.

This commit breaks compatibility with the webpack 1 pattern of specifying loader config directly in the webpack config object.

Update README accordingly.