### PR TITLE
Enable directory deps and error when missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Can be configured with [query parameters](https://webpack.github.io/docs/using-l
 | ------ | ------- | ----------- |
 | `dependenciesRoot` | `"app"` | The root of your Rails project, relative to `webpack`'s working directory. |
 | `engine` | `"erubis"` | ERB Template engine, `"erubis"` and `"erb"` are supported right now. |
-| `parseComments` | `true` | Search files for [configuration comments](#configuration-comments) before compiling. |
 | `runner` | `"./bin/rails runner"` | Command to run Ruby scripts, relative to `webpack`'s working directory. |
 
 These options may also be specified directly in your `webpack` config. For example, if your `webpack` process is running in a subdirectory of your Rails project:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ npm install rails-erb-loader --save-dev
 
 ## Usage
 
-Add `rails-erb-loader` to your preloaders.
+Add `rails-erb-loader` to your rules.
 
 ```js
 // webpack.config.js
@@ -46,6 +46,41 @@ module.exports = {
     }
   }
 };
+```
+
+Now you can use `.erb` files in your project, for example:
+
+`app/assets/javascripts/UserFormFields.jsx.erb`
+```erb
+/* rails-erb-loader-dependencies models/user models/image */
+
+export default function UserFormFields() {
+  return (
+    <div>
+      <label htmlFor='avatar'>
+        Avatar
+      </label>
+      <ImageField id='avatar' maxSize={<%= Image::MAX_SIZE %>} />
+      <label htmlFor='name'>
+        Name
+      </label>
+      <input
+        id='name'
+        type='text'
+        maxLength={<%= User::MAX_NAME_LENGTH %>}
+      />
+      <label htmlFor='age'>
+        Age
+      </label>
+      <input
+        id='age'
+        type='number'
+        min={<%= User::MIN_AGE %>}
+        max={<%= User::MAX_AGE %>}
+      />
+    </div>
+  )
+}
 ```
 
 ## Configuration
@@ -88,48 +123,24 @@ Also supports building without Rails:
 }
 ```
 
-### Configuration comments
+### Dependencies
 
-`rails-erb-loader` will parse files for overrides to query parameters. These must be `/* ... */` style block comments starting with the correct `rails-erb-loader-*` command. This comment syntax is supported in JavaScript, CSS, SASS and less.
+If your `.erb` files depend on files in your Ruby project, you can list them explicitly. Inclusion of the `rails-erb-loader-dependency` (or `-dependencies`) comment will tell `webpack` to watch these files - causing webpack-dev-server to rebuild when they are changed.
 
-#### `rails-erb-loader-dependencies`
+#### Watch individual files
 
-If your `.erb` files depend on files in your Ruby project, you can list them explicitly. Inclusion of the `rails-erb-loader-dependency` (or `-dependencies`) comment will tell `webpack` to watch these files and rebuild when they are changed.
+List dependencies in the comment. `.rb` extension is optional.
 
-Here is an example React component that depends on the `User` and `Image` Rails models:
+```js
+/* rails-erb-loader-dependencies models/account models/user */
+```
 
-```erb
-// app/assets/javascripts/UserFormFields.js
+#### Watch a whole directory
 
-/* rails-erb-loader-dependencies models/user models/image */
+To watch all files in a directory, end the path in a `/`.
 
-export default function UserFormFields() {
-  return (
-    <div>
-      <label htmlFor='avatar'>
-        Avatar
-      </label>
-      <ImageField id='avatar' maxSize={<%= Image::MAX_SIZE %>} />
-      <label htmlFor='name'>
-        Name
-      </label>
-      <input
-        id='name'
-        type='text'
-        maxLength={<%= User::MAX_NAME_LENGTH %>}
-      />
-      <label htmlFor='age'>
-        Age
-      </label>
-      <input
-        id='age'
-        type='number'
-        min={<%= User::MIN_AGE %>}
-        max={<%= User::MAX_AGE %>}
-      />
-    </div>
-  )
-}
+```js
+/* rails-erb-loader-dependencies ../config/locales/ */
 ```
 
 ## Contribute

--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Can be configured with [query parameters](https://webpack.github.io/docs/using-l
 
 | Option | Default | Description |
 | ------ | ------- | ----------- |
-| `dependencies` | `[]` | A list of Ruby files to watch for changes. |
 | `dependenciesRoot` | `"app"` | The root of your Rails project, relative to `webpack`'s working directory. |
 | `engine` | `"erubis"` | ERB Template engine, `"erubis"` and `"erb"` are supported right now. |
 | `parseComments` | `true` | Search files for [configuration comments](#configuration-comments) before compiling. |

--- a/index.js
+++ b/index.js
@@ -126,12 +126,15 @@ module.exports = function railsErbLoader (source, map) {
   // Modifying the return value of `getOptions` is not permitted.
   var config = defaults({}, getOptions(loader), {
     dependenciesRoot: 'app',
-    parseComments: true,
     runner: './bin/rails runner',
     engine: 'erubis'
   })
 
-  var dependencies = parseDependencies(source, config.dependenciesRoot)
+  // If we're in development then there's no point running regexes to add
+  // dependencies.
+  var dependencies = process.env.NODE_ENV === 'development'
+    ? parseDependencies(source, config.dependenciesRoot)
+    : []
 
   var callback = loader.async()
 

--- a/index.js
+++ b/index.js
@@ -1,3 +1,4 @@
+var fs = require('fs')
 var exec = require('child_process').exec
 var path = require('path')
 var getOptions = require('loader-utils').getOptions
@@ -15,12 +16,9 @@ var ioDelimiter = '_' + '_RAILS_ERB_LOADER_DELIMETER__'
 /* Match any block comments that start with the string `rails-erb-loader-*`. */
 var configCommentRegex = /\/\*\s*rails-erb-loader-([a-z-]*)\s*([\s\S]*?)\s*\*\//g
 
-/* Match any path ending with a file extension */
-var fileExtensionRegex = /\.\w*$/
-
-/* Takes a path and attaches `.rb` if it does not already have an extension. */
+/* Takes a path and attaches `.rb` if it has no extension nor trailing slash. */
 function defaultFileExtension (dependency) {
-  return fileExtensionRegex.test(dependency) ? dependency : dependency + '.rb'
+  return /((\.\w*)|\/)$/.test(dependency) ? dependency : dependency + '.rb'
 }
 
 /* Get each space separated path, ignoring any empty strings. */
@@ -89,6 +87,36 @@ function transformSource (runner, engine, source, map, callback) {
   child.stdin.end()
 }
 
+function addDependencies (loader, paths, callback) {
+  var remaining = paths.length
+
+  if (remaining === 0) callback(null)
+
+  paths.forEach(function (path) {
+    fs.stat(path, function (error, stats) {
+      if (error) {
+        if (error.code === 'ENOENT') {
+          callback(new Error('Could not find dependency "' + path + '"'))
+        } else {
+          callback(error)
+        }
+      } else {
+        if (stats.isFile()) {
+          loader.addDependency(path)
+        } else if (stats.isDirectory()) {
+          loader.addContextDependency(path)
+        } else {
+          console.warning(
+            'rails-erb-loader ignored dependency that was neither a file nor a directory'
+          )
+        }
+        remaining--
+        if (remaining === 0) callback(null)
+      }
+    })
+  })
+}
+
 module.exports = function railsErbLoader (source, map) {
   var loader = this
 
@@ -120,12 +148,14 @@ module.exports = function railsErbLoader (source, map) {
     parseComments(source, config)
   }
 
-  // Register watchers for any dependencies.
-  config.dependencies.forEach(function (dependency) {
-    loader.addDependency(dependency)
-  })
-
-  // Now actually transform the source.
   var callback = loader.async()
-  transformSource(config.runner, config.engine, source, map, callback)
+
+  // Register watchers for any dependencies.
+  addDependencies(loader, config.dependencies, function (error) {
+    if (error) {
+      callback(error)
+    } else {
+      transformSource(config.runner, config.engine, source, map, callback)
+    }
+  })
 }


### PR DESCRIPTION
Allow directories to be added as dependencies by trailing with `/`. Closes  #10

Raise an error when specified dependency cannot be found. Closes #24