### PR TITLE
Support erubi loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Can be configured with [UseEntry#options](https://webpack.js.org/configuration/m
 | Option | Default | Description |
 | ------ | ------- | ----------- |
 | `dependenciesRoot` | `"app"` | The root of your Rails project, relative to webpack's working directory. |
-| `engine` | `"erubis"` | ERB Template engine, `"erubis"` and `"erb"` are supported. |
+| `engine` | `"erb"` | ERB Template engine, `"erubi"`, `"erubis"` and `"erb"` are supported. |
 | `runner` | `"./bin/rails runner"` | Command to run Ruby scripts, relative to webpack's working directory. |
 
 For example, if your webpack process is running in a subdirectory of your Rails project:

--- a/erb_transformer.rb
+++ b/erb_transformer.rb
@@ -1,6 +1,9 @@
 delimiter = ARGV[0]
 engine = ARGV[1]
 handler = case engine
+  when 'erubi'
+    require 'erubi'
+    Erubi::Engine
   when 'erubis'
     require 'erubis'
     Erubis::Eruby
@@ -10,4 +13,8 @@ handler = case engine
   else raise "Unknown templating engine `#{engine}`"
 end
 
-puts "#{delimiter}#{handler.new(STDIN.read).result}#{delimiter}"
+if engine == 'erubi'
+  puts "#{delimiter}#{eval(handler.new(STDIN.read).src)}#{delimiter}"
+else
+  puts "#{delimiter}#{handler.new(STDIN.read).result}#{delimiter}"
+end

--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ module.exports = function railsErbLoader (source, map) {
   var config = defaults({}, getOptions(loader), {
     dependenciesRoot: 'app',
     runner: './bin/rails runner',
-    engine: 'erubis'
+    engine: 'erb'
   })
 
   // If we're in development then there's no point running regexes to add


### PR DESCRIPTION
* Add support for `erubi`. In Rails 5.1 the ERB engine switched to `erubi`.
* Change default engine to `erb`, which works for Rails < 5.1 and Rails >= 5.1.

See:
https://github.com/usabilityhub/rails-erb-loader/issues/30
https://github.com/rails/webpacker/pull/220