### PR TITLE
Wrap transformer path with quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,9 @@ function parseDependencies (source, root) {
  * output transformed source.
  */
 function transformSource (runner, engine, source, map, callback) {
+  var transformerPath = '\'' + path.join(__dirname, 'erb_transformer.rb') + '\''
   var child = exec(
-    runner + ' ' + path.join(__dirname, 'erb_transformer.rb') + ' ' + ioDelimiter + ' ' + engine,
+    runner + ' ' + transformerPath + ' ' + ioDelimiter + ' ' + engine,
     function (error, stdout) {
       // Output is delimited to filter out unwanted warnings or other output
       // that we don't want in our files.


### PR DESCRIPTION
If `__dirname` contained spaces `exec` will fail because it runs the command in a shell. A quick fix would be to wrap the `__dirname` in single quotes.

I don't know Node very well and googling around I couldn't find a builtin safe escaper for command arguments. I think the best way to handle this is to depend on a library that does this, but that is up to you.