### PR TITLE
Fix: rubocop Lint/EndAlignment and Layout/CaseIndentation

### DIFF
--- a/erb_transformer.rb
+++ b/erb_transformer.rb
@@ -1,17 +1,17 @@
 delimiter = ARGV[0]
 engine = ARGV[1]
 handler = case engine
-  when 'erubi'
-    require 'erubi'
-    Erubi::Engine
-  when 'erubis'
-    require 'erubis'
-    Erubis::Eruby
-  when 'erb'
-    require 'erb'
-    ERB
-  else raise "Unknown templating engine `#{engine}`"
-end
+          when 'erubi'
+            require 'erubi'
+            Erubi::Engine
+          when 'erubis'
+            require 'erubis'
+            Erubis::Eruby
+          when 'erb'
+            require 'erb'
+            ERB
+          else raise "Unknown templating engine `#{engine}`"
+          end
 
 if engine == 'erubi'
   puts "#{delimiter}#{eval(handler.new(STDIN.read).src)}#{delimiter}"


### PR DESCRIPTION
http://www.rubydoc.info/github/bbatsov/rubocop/Rubocop/Cop/Lint/EndAlignment
http://www.rubydoc.info/github/bbatsov/RuboCop/RuboCop/Cop/Layout/CaseIndentation