### PR TITLE
use quotes to reference the runnerPath when spewing the command

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function transformSource (runner, config, source, map, callback) {
   var child = spawn(
     runner.file,
     runner.arguments.concat(
-      runnerPath,
+      `"${runnerPath}"`,
       ioDelimiter,
       config.engine
     ),


### PR DESCRIPTION
Looks like the rails runner interprets anything starting with a `/` as a regex so when the `runnerPath` ends up being an absolute path it breaks.